### PR TITLE
💄 체크박스 컴포넌트 스타일 추가

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -13,6 +13,7 @@ const config: StorybookConfig = {
     '@storybook/addon-onboarding',
     '@storybook/addon-interactions',
   ],
+  staticDirs: ['../public'],
   framework: {
     name: '@storybook/nextjs',
     options: {},

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  compiler: {
+    styledComponents: true,
+  },
 };
 
 module.exports = nextConfig;

--- a/public/icons/Check.svg
+++ b/public/icons/Check.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="9" viewBox="0 0 14 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12.5 1L5.16663 8L1.5 4.5" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icons/Check_simple.svg
+++ b/public/icons/Check_simple.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="9" viewBox="0 0 14 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12.5 1L5.16663 8L1.5 4.5" stroke="#cccfd3" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icons/Check_simple_checked.svg
+++ b/public/icons/Check_simple_checked.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="9" viewBox="0 0 14 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12.5 1L5.16663 8L1.5 4.5" stroke="#5C42FF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/Checkbox/Checkbox.stories.ts
+++ b/src/components/Checkbox/Checkbox.stories.ts
@@ -6,6 +6,9 @@ const meta: Meta<typeof Checkbox> = {
   title: 'components/Checkbox',
   component: Checkbox,
   argTypes: {
+    shapes: {
+      description: '체크박스 모양을 결정합니다.',
+    },
     label: {
       description: '라벨 이름을 정합니다.',
     },
@@ -21,24 +24,27 @@ const meta: Meta<typeof Checkbox> = {
 export default meta;
 type Story = StoryObj<typeof Checkbox>;
 
-export const Default: Story = {
+export const Circle_Checkbox: Story = {
   args: {
+    shapes: 'circle',
     id: 'id',
     label: '라벨',
     checked: false,
   },
 };
 
-export const Checked: Story = {
+export const Simple_Checkbox: Story = {
   args: {
+    shapes: 'simple',
     id: 'id',
     label: '라벨',
-    checked: true,
+    checked: false,
   },
 };
 
 export const Disabled: Story = {
   args: {
+    shapes: 'simple',
     id: 'id',
     label: '라벨',
     disabled: true,

--- a/src/components/Checkbox/Checkbox.styled.ts
+++ b/src/components/Checkbox/Checkbox.styled.ts
@@ -2,6 +2,16 @@ import styled from 'styled-components';
 
 import type { CheckboxProps } from './types';
 
+const CHECKBOX_SHAPES: Record<CheckboxProps['shapes'], string> = {
+  circle: "#cccfd3 url('/icons/Check.svg') 50% 50% no-repeat",
+  simple: "url('/icons/Check_simple.svg') 50% 50% no-repeat",
+};
+
+const CHECKBOX_SHAPES_CHECKED: Record<CheckboxProps['shapes'], string> = {
+  circle: "#5c42ff url('/icons/Check.svg') 50% 50% no-repeat",
+  simple: "url('/icons/Check_simple_checked.svg') 50% 50% no-repeat",
+};
+
 const CheckboxContainer = styled.div`
   display: flex;
   align-items: center;
@@ -11,10 +21,19 @@ const CheckboxContainer = styled.div`
   }
 `;
 
-const Checkbox = styled.input<CheckboxProps>`
+const Checkbox = styled.input.attrs({
+  type: 'checkbox',
+})<CheckboxProps>`
+  appearance: none;
   width: 24px;
   height: 24px;
   cursor: pointer;
+  border-radius: 50%;
+  background: ${({ shapes }) => CHECKBOX_SHAPES[shapes]};
+
+  &:checked {
+    background: ${({ shapes }) => CHECKBOX_SHAPES_CHECKED[shapes]};
+  }
 `;
 
 export default { CheckboxContainer, Checkbox };

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -1,14 +1,22 @@
+import { useState } from 'react';
 import S from './Checkbox.styled';
 
 import type { CheckboxProps } from './types';
 
-const Checkbox = ({ id, label, checked, disabled = false, onChange, ...args }: CheckboxProps) => {
+const Checkbox = ({ shapes, id, label, checked, disabled = false, ...args }: CheckboxProps) => {
+  const [isChecked, setIsChecked] = useState<boolean>(checked);
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setIsChecked(e.target.checked);
+  };
+
   return (
     <S.CheckboxContainer>
       <S.Checkbox
         type="checkbox"
+        shapes={shapes}
         id={id}
-        checked={checked}
+        checked={isChecked}
         disabled={disabled}
         onChange={onChange}
         {...args}

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -1,24 +1,16 @@
-import { useState } from 'react';
 import S from './Checkbox.styled';
 
 import type { CheckboxProps } from './types';
 
 const Checkbox = ({ shapes, id, label, checked, disabled = false, ...args }: CheckboxProps) => {
-  const [isChecked, setIsChecked] = useState<boolean>(checked);
-
-  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setIsChecked(e.target.checked);
-  };
-
   return (
     <S.CheckboxContainer>
       <S.Checkbox
         type="checkbox"
         shapes={shapes}
         id={id}
-        checked={isChecked}
+        checked={checked}
         disabled={disabled}
-        onChange={onChange}
         {...args}
       />
       {label && <label htmlFor={id}>{label}</label>}

--- a/src/components/Checkbox/types.ts
+++ b/src/components/Checkbox/types.ts
@@ -1,9 +1,9 @@
-import type { InputHTMLAttributes } from 'react';
+import type { ReactNode, InputHTMLAttributes } from 'react';
 
 export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
   shapes: 'circle' | 'simple';
   id: string;
-  label?: string;
+  label?: ReactNode;
   checked: boolean;
   disabled?: boolean;
 }

--- a/src/components/Checkbox/types.ts
+++ b/src/components/Checkbox/types.ts
@@ -1,6 +1,7 @@
 import type { InputHTMLAttributes } from 'react';
 
 export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
+  shapes: 'circle' | 'simple';
   id: string;
   label?: string;
   checked: boolean;

--- a/src/components/Chip/Chip.stories.ts
+++ b/src/components/Chip/Chip.stories.ts
@@ -1,0 +1,38 @@
+import Chip from './index';
+import { action } from '@storybook/addon-actions';
+
+import type { StoryObj, Meta } from '@storybook/react';
+
+const meta: Meta<typeof Chip> = {
+  title: 'components/Chip',
+  component: Chip,
+  argTypes: {
+    isClicked: {
+      description: '클릭 여부를 결정합니다.',
+    },
+    value: {
+      description: '칩 버튼의 value값을 정합니다.',
+    },
+    onClick: {
+      description: '클릭 시 실행 될 함수를 넣습니다.',
+    },
+  },
+};
+export default meta;
+type Story = StoryObj<typeof Chip>;
+
+export const Default: Story = {
+  args: {
+    isClicked: false,
+    value: 'MBTI',
+    onClick: () => action('onClick Triggered')('test'),
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    isClicked: false,
+    value: 'MBTI',
+    disabled: true,
+  },
+};

--- a/src/components/Chip/Chip.styled.ts
+++ b/src/components/Chip/Chip.styled.ts
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+import type { ChipProps } from './types';
+
+const Chip = styled.button<ChipProps>`
+  width: 66px;
+  height: 40px;
+  font-size: 14px;
+  border: ${({ disabled, isClicked }) =>
+    disabled === false && isClicked ? 'none' : '1px solid #6E6F73'};
+  border-radius: 33px;
+  background-color: ${({ disabled, isClicked }) =>
+    disabled === false && isClicked ? '#5C42FF' : 'transparent'};
+  color: white;
+`;
+
+export default { Chip };

--- a/src/components/Chip/index.tsx
+++ b/src/components/Chip/index.tsx
@@ -1,0 +1,13 @@
+import S from './Chip.styled';
+
+import type { ChipProps } from './types';
+
+const Chip = ({ isClicked, value, disabled = false, ...args }: ChipProps) => {
+  return (
+    <S.Chip isClicked={isClicked} value={value} disabled={disabled} {...args}>
+      {value}
+    </S.Chip>
+  );
+};
+
+export default Chip;

--- a/src/components/Chip/types.ts
+++ b/src/components/Chip/types.ts
@@ -1,0 +1,8 @@
+import { ButtonHTMLAttributes } from 'react';
+
+export interface ChipProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  isClicked: boolean;
+  value: string;
+  disabled?: boolean;
+  onClick?: () => void;
+}


### PR DESCRIPTION
# 💄 체크박스 컴포넌트 스타일 추가

### 작업 사항
![test_checkbox](https://github.com/gdg-temp/client/assets/107452022/84a48300-f96d-424d-8355-0a3ad707e3df)

- 피그마의 체크박스 스타일 2개를 적용하였습니다.
- 스토리북에 정적디렉토리를 설정하였습니다.
- 새로고침 후 스타일 적용이 사라지는 이슈를 해결하였습니다.

<br/>

### 참고 사항

- 라벨의 폰트는 아직 설정하지 않았는데 추후 폰트추가되면 설정하겠습니다.
- 폰트 사이즈의 경우 사용하는 곳에서 커스텀하여 사용해야할지 정해진 크기들을 설정해두어야 할지 논의해봐야할 것 같습니다.
- MDN에서 지원하는 브라우저 참고하여 apperance 속성을 적용하였습니다. 
 (https://developer.mozilla.org/en-US/docs/Web/CSS/appearance)

<br/>

closed #16 

<br/>
