### PR TITLE
:alien: 브라우저->Backend Server 에서 Next Server->Backend Server로 방식 변경

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,14 @@ const nextConfig = {
   compiler: {
     styledComponents: true,
   },
+  async rewrites() {
+    return [
+      {
+        source: '/v1/api/:path*',
+        destination: `${process.env.NEXT_PUBLIC_API_URL}/:path*`,
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
 export const axiosInstance = axios.create({
-  baseURL: `${process.env.NEXT_PUBLIC_API_URL}`,
+  baseURL: `/v1/api`,
   timeout: 10000,
 });

--- a/src/utils/getServerSideCardProps/index.tsx
+++ b/src/utils/getServerSideCardProps/index.tsx
@@ -1,5 +1,6 @@
 import { GetServerSideProps } from 'next';
-import { getUser, getCard } from '@api';
+import axios from 'axios';
+import { ResponseData } from 'src/api/types';
 
 import type { User, Card } from '@types';
 
@@ -16,13 +17,18 @@ const getServerSideCardProps: GetServerSideProps<{
   let user = {} as User;
   let card = {} as Card;
   try {
-    const cardResponse = await getCard(ctx.query.id as string, config);
+    const { data: cardResponse } = await axios.get<ResponseData<Card>>(
+      `${process.env.NEXT_PUBLIC_API_URL}/cards/${ctx.query.id}`,
+    );
     card = cardResponse.data;
   } catch (error) {
     console.log('CARD ERROR');
   }
   try {
-    const userResponse = await getUser(config);
+    const { data: userResponse } = await axios.get<ResponseData<User>>(
+      `${process.env.NEXT_PUBLIC_API_URL}/user`,
+      config,
+    );
     user = userResponse.data;
   } catch (error) {
     console.log('USER ERROR');

--- a/src/utils/getServerSideUserProps/index.tsx
+++ b/src/utils/getServerSideUserProps/index.tsx
@@ -1,5 +1,6 @@
 import { GetServerSideProps } from 'next';
-import { getUser } from '@api';
+import axios from 'axios';
+import { ResponseData } from 'src/api/types';
 
 import type { User } from '@types';
 
@@ -8,16 +9,20 @@ const getServerSideUserProps: GetServerSideProps<{
 }> = async (ctx) => {
   const cookies = ctx.req.headers.cookie;
   const path = ctx.resolvedUrl;
+  const config = {
+    headers: {
+      cookie: cookies,
+    },
+  };
   const isOnlyLoggedInPage =
     path === '/collections' || path === '/settings' || path.includes('edit');
 
   let user = {} as User;
   try {
-    const userResponse = await getUser({
-      headers: {
-        cookie: cookies,
-      },
-    });
+    const { data: userResponse } = await axios.get<ResponseData<User>>(
+      `${process.env.NEXT_PUBLIC_API_URL}/user`,
+      config,
+    );
     user = userResponse.data;
   } catch (error) {
     // 에러 및 로그인 X


### PR DESCRIPTION
# 👽 브라우저->Backend Server 에서 Next Server->Backend Server로 방식 변경

### 작업 사항

- 도메인 주소를 프론트에서 사용함에 따라 백엔드 요청시 다른 url로 보내야하는 상황.
- 백엔드에서 사용중인 aws 내부 url을 찔러야하지만 CORS이슈와 더불어 해당 Url을 가려야하므로 server to server 방식으로 변경

<br/>

### 참고 사항

- 리뷰어가 참고할 만한 상세 내용 1

<br/>

closed #{이슈번호}

<br/>
